### PR TITLE
Allow storing files in S3, instead of just on-disk

### DIFF
--- a/docstore
+++ b/docstore
@@ -2,6 +2,7 @@
 
 import base64
 from datetime import datetime, time
+import json
 import logging
 import mimetypes
 import os
@@ -10,6 +11,7 @@ import sys
 from urllib.parse import quote, unquote, unquote_plus, urlencode
 
 import bleach
+import boto3
 from dateutil import tz
 from feedgen.feed import FeedGenerator
 import markdown
@@ -56,12 +58,14 @@ class IndexHandler(RequestHandler):
 class AddHandler(RequestHandler):
 
     def initialize(
-        self, region, google_analytics_id, SessionMaker, stored_docs_path):
+        self, region, google_analytics_id, SessionMaker, stored_docs_path,
+        s3_bucket_name=None):
 
         self.__region = region
         self.__google_analytics_id = google_analytics_id
         self.__SessionMaker = SessionMaker
         self.__stored_docs_path = stored_docs_path
+        self.__s3_bucket_name = s3_bucket_name
 
     def get(self):
         authorized = self.get_secure_cookie('authorized')
@@ -77,7 +81,8 @@ class AddHandler(RequestHandler):
 
         self.render(
             'add.html', region=self.__region, org_names=org_names,
-            google_analytics_id=self.__google_analytics_id, authorized=authorized
+            google_analytics_id=self.__google_analytics_id,
+            authorized=authorized
             )
 
     def post(self):
@@ -133,21 +138,35 @@ class AddHandler(RequestHandler):
         document_id = new_doc.id
         session.close()
 
-        # Make the directory
-        directory = os.path.join(self.__stored_docs_path, str(document_id))
-        os.mkdir(directory)
+        # If S3 is configured, save file there
+        if self.__s3_bucket_name:
+            s3_client = boto3.client('s3')
 
-        # Write out the files to disk
-        for each_file in file_array:
-            file_data = each_file['body']
-            filename = each_file['filename']
+            for each_file in file_array:
+                s3_key = 'file/{}/{}'.format(document_id, each_file['filename'])
+                s3_client.put_object(
+                    Body=each_file['body'],
+                    Bucket=self.__s3_bucket_name,
+                    Key=s3_key,
+                )
 
-            # Use id number to write to disk
-            file_path = os.path.join(directory, filename)
+        # Otherwise, save to disk
+        else:
+            # Make the directory
+            directory = os.path.join(self.__stored_docs_path, str(document_id))
+            os.mkdir(directory)
 
-            fd = open(file_path, 'wb')
-            fd.write(file_data)
-            fd.close()
+            # Write out the files to disk
+            for each_file in file_array:
+                file_data = each_file['body']
+                filename = each_file['filename']
+
+                # Use id number to write to disk
+                file_path = os.path.join(directory, filename)
+
+                fd = open(file_path, 'wb')
+                fd.write(file_data)
+                fd.close()
 
         self.set_cookie('notification', quote('Document added; thanks!'))
         self.redirect('/')
@@ -238,12 +257,14 @@ class LegacyFileHandler(RequestHandler):
 class ViewHandler(RequestHandler):
 
     def initialize(
-            self, region, google_analytics_id, SessionMaker, stored_docs_path):
+            self, region, google_analytics_id, SessionMaker, stored_docs_path,
+            s3_bucket_name=None):
 
         self.__region = region
         self.__google_analytics_id = google_analytics_id
         self.__SessionMaker = SessionMaker
         self.__stored_docs_path = stored_docs_path
+        self.__s3_bucket_name = s3_bucket_name
 
     def get(self, document_id, filename=None):
         authorized = self.get_secure_cookie('authorized')
@@ -252,26 +273,62 @@ class ViewHandler(RequestHandler):
         doc = session.query(DocModel).filter(DocModel.id == document_id).one()
         session.close()
 
-        # Get file names
-        doc_folder = os.path.join(self.__stored_docs_path, str(document_id))
-        files = os.listdir(doc_folder)
+        allowed_tags = bleach.ALLOWED_TAGS + ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'pre']
+
+        files = []
+
+        # If S3 is configured, check there first
+        if self.__s3_bucket_name:
+            s3_client = boto3.client('s3')
+            objects = s3_client.list_objects(
+                Bucket=self.__s3_bucket_name,
+                Prefix='file/{}/'.format(document_id),
+            )
+
+            for each_object in objects.get('Contents', []):
+                files.append(each_object['Key'].split('/')[-1])
+
+        # If we didn't find anything, check on-disk
+        if not files:
+            doc_folder = os.path.join(self.__stored_docs_path, str(document_id))
+            files.extend(os.listdir(doc_folder))
 
         self.render(
             'view.html', region=self.__region,
             google_analytics_id=self.__google_analytics_id,
             authorized=authorized, doc=doc, filename=filename, bleach=bleach,
-            markdown=markdown, allowed_tags=BLEACH_ALLOWED_TAGS, files=files,
-            urlencode=urlencode
+            markdown=markdown, allowed_tags=allowed_tags, files=files,
+            urlencode=urlencode, xsrf_token=self.xsrf_token,
             )
 
 
 class DownloadHandler(RequestHandler):
 
-    def initialize(self, stored_docs_path):
+    def initialize(self, stored_docs_path, s3_bucket_name=None):
         self.__stored_docs_path = stored_docs_path
+        self.__s3_bucket_name = s3_bucket_name
 
     def get(self, doc_id, filename):
         filename = unquote_plus(filename)
+
+        # If S3 is configured, attempt to get file from there
+        if self.__s3_bucket_name:
+            s3_key = 'file/{}/{}'.format(doc_id, filename)
+            s3_client = boto3.client('s3')
+            objects = s3_client.list_objects(
+                Bucket=self.__s3_bucket_name,
+                Prefix=s3_key,
+            )
+
+            if objects.get('Contents'):
+                presigned_url = s3_client.generate_presigned_url(
+                    'get_object',
+                    Params={'Bucket': self.__s3_bucket_name, 'Key': s3_key},
+                )
+                self.redirect(presigned_url)
+                return
+
+        # Object was not in S3, so try on-disk
         file_path = os.path.join(self.__stored_docs_path, str(doc_id), filename)
 
         if not os.path.exists(file_path):
@@ -371,9 +428,10 @@ class EditHandler(RequestHandler):
 
 class DeleteHandler(RequestHandler):
 
-    def initialize(self, SessionMaker, stored_docs_path):
+    def initialize(self, SessionMaker, stored_docs_path, s3_bucket_name):
         self.__SessionMaker = SessionMaker
         self.__stored_docs_path = stored_docs_path
+        self.__s3_bucket_name = s3_bucket_name
 
     def post(self):
         # Make sure we are authorized
@@ -384,15 +442,36 @@ class DeleteHandler(RequestHandler):
             self.write('Not authorized')
             return
 
-        doc_id = self.get_argument('doc_id', None)
+        body_dict = json.loads(self.request.body)
+        doc_id = body_dict.get('doc_id')
 
         if not doc_id:
-            self.set_stataus(401)
+            self.set_status(401)
             self.write('Bad request, no doc_id')
             return
 
-        # Remove file on disk
-        shutil.rmtree(os.path.join(self.__stored_docs_path, str(doc_id)))
+        # If S3 is configured, check if we should remove files
+        if self.__s3_bucket_name:
+            s3_client = boto3.client('s3')
+            objs = s3_client.list_objects(
+                Bucket=self.__s3_bucket_name,
+                Prefix='file/{}/'.format(doc_id),
+            )
+
+            objects = [{'Key': each['Key']} for each in objs.get('Contents', [])]
+            if objects:
+                s3_client.delete_objects(
+                    Bucket=self.__s3_bucket_name,
+                    Delete={'Objects': objects},
+                )
+
+        # Check if we should remove files from on-disk
+        doc_folder = os.path.join(self.__stored_docs_path, str(doc_id))
+        try:
+            os.listdir(doc_folder)
+            shutil.rmtree(doc_folder)
+        except FileNotFoundError:
+            pass
 
         # Remove metadata
         session = self.__SessionMaker()
@@ -402,7 +481,7 @@ class DeleteHandler(RequestHandler):
 
         self.set_cookie(
             'notification',
-            quote('Deleted document: {}'.format(doc.doc_title.encode('utf8')))
+            quote('Deleted document: {}'.format(doc.doc_title)),
             )
 
         self.write({'success': True})
@@ -479,6 +558,8 @@ class AuthHandler(RequestHandler):
 
         # If not, make sure basic auth is submitted
         auth_header = self.request.headers.get('Authorization')
+        if auth_header:
+            auth_header = auth_header.encode('utf8')
 
         if not auth_header:
             self.set_header('WWW-Authenticate', 'Basic realm=/auth/')
@@ -487,7 +568,7 @@ class AuthHandler(RequestHandler):
 
         else:
             # We have basic auth info; check it
-            auth_decoded = base64.decodestring(auth_header[6:])
+            auth_decoded = base64.decodestring(auth_header[6:]).decode('utf8')
             username, password = auth_decoded.split(':', 2)
 
             if password == self.__password:
@@ -653,7 +734,8 @@ if __name__ == '__main__':
             region=settings['region'],
             google_analytics_id=google_analytics_id,
             SessionMaker=SessionMaker,
-            stored_docs_path=stored_docs_path
+            stored_docs_path=stored_docs_path,
+            s3_bucket_name=settings.get('s3_bucket_name'),
             )),
 
         (r'/search', SearchHandler, dict(
@@ -672,7 +754,8 @@ if __name__ == '__main__':
             region=settings['region'],
             google_analytics_id=google_analytics_id,
             SessionMaker=SessionMaker,
-            stored_docs_path=stored_docs_path
+            stored_docs_path=stored_docs_path,
+            s3_bucket_name=settings.get('s3_bucket_name'),
             )),
 
         (r'/view/([0-9]+)/(.*)', ViewHandler, dict(
@@ -683,7 +766,8 @@ if __name__ == '__main__':
             )),
 
         (r'/file/([0-9]+)/(.*)', DownloadHandler, dict(
-            stored_docs_path=stored_docs_path
+            stored_docs_path=stored_docs_path,
+            s3_bucket_name=settings.get('s3_bucket_name'),
             )),
 
         (r'/edit/([0-9]+)', EditHandler, dict(
@@ -694,7 +778,8 @@ if __name__ == '__main__':
 
         (r'/delete', DeleteHandler, dict(
             SessionMaker=SessionMaker,
-            stored_docs_path=stored_docs_path
+            stored_docs_path=stored_docs_path,
+            s3_bucket_name=settings.get('s3_bucket_name'),
             )),
 
         (r'/orgs', OrgHandler, dict(
@@ -717,7 +802,8 @@ if __name__ == '__main__':
 
         template_path=template_path,
         cookie_secret=settings['cookie_secret'],
-        xsrf_cookies=True
+        xsrf_cookies=True,
+        debug=settings.get('debug', False),
         )
 
     server = HTTPServer(app, max_buffer_size=max_file_size)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-bleach>=1.4.2
+bleach>=3.2.1
+boto3>=1.16.56
+botocore>=1.19.56
 feedgen>=0.8.0
-Markdown>=2.6.5
-PyYAML>=3.10
-SQLAlchemy>=0.9.1
-tornado>=4.3
+Markdown>=3.3.3
+PyYAML>=5.3.1
+SQLAlchemy>=1.3.22
+tornado>=6.1

--- a/settings.sample.yml
+++ b/settings.sample.yml
@@ -3,3 +3,4 @@ password: '__make_your_own_management_password__'
 cookie_secret: '__this_can_be_anything_it_is_just_for_the_server__'
 google_analytics_id: '__optional_just_remove_this_line_if_not_needed__'
 max_file_size: 104857600
+s3_bucket_name: 'your_s3_bucket_name'

--- a/templates/view.html
+++ b/templates/view.html
@@ -4,41 +4,6 @@
   {{ doc.doc_title }}
 {% end %}
 
-{% block head %}
-  {% if authorized %}
-    <script type='text/javascript'>
-      $(document).ready(function() {
-        function get_cookie(name) {
-          var r = document.cookie.match("\\b" + name + "=([^;]*)\\b");
-          return r ? r[1] : undefined;
-        }
-
-        $('#delete').click(function() {
-          var confirm_response = confirm('Are you sure you want to delete? There is no undo.');
-
-          data = {
-            'doc_id': {{ doc.id }},
-            '_xsrf': get_cookie('_xsrf')
-            };
-
-          if (confirm_response == true) {
-            $.ajax({
-              'type': 'POST',
-              'url': '/delete',
-              'data': data,
-              'success': function(response) {
-                if (response['success']) {
-                  window.location = '/';
-                }
-              }
-            });
-          }
-        });
-      });
-    </script>
-  {% end %}
-{% end %}
-
 {% block body %}
   <h3>Document Details</h3>
   <div class='spacer'>
@@ -105,7 +70,7 @@
         {% end %}
         <a href='/file/{{ url_escape(str(doc.id)) }}/{{ url_escape(each_file) }}'>{{ each_file }}</a>
         {% if each_file == filename %}
-            </span'>
+            </span>
         {% end %}
       </p>
     {% end %}
@@ -117,5 +82,24 @@
       <br /><br />
       <input id='delete' type='button' value='Delete Document' />
     </div>
+    <script type='text/javascript'>
+      const deleteInput = document.querySelector('input#delete');
+
+      deleteInput.addEventListener('click', async () => {
+        if (confirm('Are you sure you want to delete? There is no undo.')) {
+          ret = await fetch('/delete', {
+            method: 'POST',
+            body: JSON.stringify({'doc_id': {{ doc.id }}}),
+            headers: {'X-CSRFToken': '{{ xsrf_token }}'}
+          });
+
+          ret_json = await ret.json();
+
+          if (ret_json['success']) {
+            window.location = '/';
+          }
+        }
+      });
+    </script>
   {% end %}
 {% end %}


### PR DESCRIPTION
Allow storing files in S3, instead of just on-disk
  
These changes are backwards-compatible, so it will first check S3 and fall back to on-disk if it cannot find the file.

There's a new config option `s3_bucket_name`. We assume you have the region and AWS credentials configured in your enviornment.

Once that's configured, you can move the files that are on disk under storage/docs/* into your S3 bucket under file/* (so the root of your S3 bucket will have one directory, `file`, inside of which will be a bunch of directories with numbers, inside of which will be the actual documents).

Also update dependencies to more modern versions.