### PR TITLE
Current versions of bleach are incompatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bleach>=3.3.0
+bleach<6.0.0
 feedgen>=0.9.0
 Markdown>=3.3.4
 PyYAML>=5.4.1


### PR DESCRIPTION
Bleach with versions >= 6.6.0 have many of the tag sets, protocol sets and others converted to a frozen_set

References:
- https://github.com/stephenmcd/mezzanine/issues/2054
- https://github.com/mozilla/bleach/commit/29231a10eb983e25b59c8edc5b6abcb12dbaaabe#diff-36c5493c493d7104fbea97f896ac63105c40c705698c7aa72b8f20931d332820R479

This results in the following error when running: 

```python
    BLEACH_ALLOWED_TAGS = bleach.ALLOWED_TAGS + [
                          ~~~~~~~~~~~~~~~~~~~~^~~
        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'pre'
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ]
    ~
TypeError: unsupported operand type(s) for +: 'frozenset' and 'list'
```

I've pinned the requirement to be < 6.6.0 which works for now. 